### PR TITLE
fix: goのtoolchainバージョンを1.N.P構文で記述する

### DIFF
--- a/examples/sender/go.mod
+++ b/examples/sender/go.mod
@@ -1,6 +1,6 @@
 module sender
 
-go 1.21
+go 1.21.0
 
 require (
 	firebase.google.com/go/v4 v4.13.0

--- a/examples/topic/go.mod
+++ b/examples/topic/go.mod
@@ -1,6 +1,6 @@
 module topic
 
-go 1.21
+go 1.21.0
 
 require (
 	firebase.google.com/go/v4 v4.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crow-misia/go-push-receiver
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/crow-misia/http-ece v0.0.2


### PR DESCRIPTION
https://go.dev/doc/toolchain#version